### PR TITLE
Filter out elm-review suppressed errors

### DIFF
--- a/src/main/kotlin/org/elm/workspace/elmreview/ElmReviewJsonReport.kt
+++ b/src/main/kotlin/org/elm/workspace/elmreview/ElmReviewJsonReport.kt
@@ -20,15 +20,17 @@ fun elmReviewJsonToMessages(json: String): List<ElmReviewError> {
         }
         is Report.Specific -> {
             report.errors.flatMap { errorsForFile ->
-                errorsForFile.errors.map { error ->
-                    ElmReviewError(
-                            path = errorsForFile.path,
-                            rule = error.rule,
-                            message = error.message,
-                            region = error.region,
-                            html = chunksToHtml(error.formatted)
-                    )
-                }
+                errorsForFile.errors
+                    .filter { error -> !error.suppressed }
+                    .map { error ->
+                        ElmReviewError(
+                                path = errorsForFile.path,
+                                rule = error.rule,
+                                message = error.message,
+                                region = error.region,
+                                html = chunksToHtml(error.formatted)
+                        )
+                    }
             }
         }
     }

--- a/src/main/kotlin/org/elm/workspace/elmreview/ElmReviewTypes.kt
+++ b/src/main/kotlin/org/elm/workspace/elmreview/ElmReviewTypes.kt
@@ -55,7 +55,8 @@ data class ElmReviewIntermediateError(
         val rule: String,
         val message: String,
         val region: Region,
-        val formatted: List<Chunk>
+        val formatted: List<Chunk>,
+        val suppressed: Boolean
 )
 
 data class Region(val start: Start, val end: End)


### PR DESCRIPTION
This makes sure that suppressed errors don't show up. FYI, in my mind, we will later have a checkbox to show (or not) the suppressed errors, so that users can track and fix suppressed errors from their IDE. But for now we can just filter them out. Without this, `elm-review` will not be usable on projects with a lot of suppressed errors.